### PR TITLE
docs: simplify build instructions and disable CactusUtils thorns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,6 @@ Monte Carlo Transport framework built on CarpetX/AMReX within the Einstein Toolk
 
 - C++ with AMReX for GPU-accelerated particle containers
 - Cactus computational toolkit with CarpetX for adaptive mesh refinement
-- SimFactory for build configuration and job management
 - Mathematica/Wolfram Language for symbolic derivations (`Particles/wolfram/`)
 
 ## Project Structure
@@ -14,31 +13,24 @@ Monte Carlo Transport framework built on CarpetX/AMReX within the Einstein Toolk
 - `Particles/` — Main thorn: neutrino particle containers, geodesic integration, I/O
 - `TestNuParticles/` — Test thorn for neutrino particle simulations
 - `TestNuPcsArdBH/` — Test thorn for neutrino particles around black holes
-- `scripts/` — Build/test scripts, SimFactory configs, CI support files
+- `scripts/` — CI support files only
 
 Each thorn follows the Cactus format:
 - `configuration.ccl`, `interface.ccl`, `param.ccl`, `schedule.ccl` — Thorn metadata
 - `src/` — C++ implementation
 - `test/` — Parameter files and reference output for the test suite
 
-## Development
+## Build & Test
 
+```bash
+./agent_scripts/build_and_test.sh
 ```
-./scripts/download.sh   # Download Cactus framework and all dependencies
-./scripts/build.sh      # Build (requires ACCELERATOR, REAL_PRECISION, MODE env vars)
-./scripts/test.sh       # Run test suite (1-proc and 2-proc configurations)
-```
-
-Environment variables for build: `ACCELERATOR` (cpu/cuda/rocm), `REAL_PRECISION` (real64), `MODE` (debug/optimize).
-
-CI runs via GitHub Actions (`.github/workflows/ci.yml`) in `einsteintoolkit/carpetx` Docker containers.
 
 ## Architecture
 
 - Particles are managed via AMReX `AmrParticleContainer` with SoA attributes for momentum (`NuParticleContainers.hxx`)
 - `NuParticleContainer` handles particle push (geodesic integration), deposition, and I/O
 - Symbolic expressions in `Particles/wolfram/` generate C++ headers (`.hxx`) — do not edit generated headers directly
-- The thornlist `scripts/mctx.th` defines all external dependencies fetched by `download.sh`
 
 ## Key Patterns
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,6 @@ Monte Carlo Transport framework built on CarpetX/AMReX within the Einstein Toolk
 
 - C++ with AMReX for GPU-accelerated particle containers
 - Cactus computational toolkit with CarpetX for adaptive mesh refinement
-- SimFactory for build configuration and job management
 - Mathematica/Wolfram Language for symbolic derivations (`Particles/wolfram/`)
 
 ## Project Structure
@@ -14,31 +13,24 @@ Monte Carlo Transport framework built on CarpetX/AMReX within the Einstein Toolk
 - `Particles/` — Main thorn: neutrino particle containers, geodesic integration, I/O
 - `TestNuParticles/` — Test thorn for neutrino particle simulations
 - `TestNuPcsArdBH/` — Test thorn for neutrino particles around black holes
-- `scripts/` — Build/test scripts, SimFactory configs, CI support files
+- `scripts/` — CI support files only
 
 Each thorn follows the Cactus format:
 - `configuration.ccl`, `interface.ccl`, `param.ccl`, `schedule.ccl` — Thorn metadata
 - `src/` — C++ implementation
 - `test/` — Parameter files and reference output for the test suite
 
-## Development
+## Build & Test
 
+```bash
+./agent_scripts/build_and_test.sh
 ```
-./scripts/download.sh   # Download Cactus framework and all dependencies
-./scripts/build.sh      # Build (requires ACCELERATOR, REAL_PRECISION, MODE env vars)
-./scripts/test.sh       # Run test suite (1-proc and 2-proc configurations)
-```
-
-Environment variables for build: `ACCELERATOR` (cpu/cuda/rocm), `REAL_PRECISION` (real64), `MODE` (debug/optimize).
-
-CI runs via GitHub Actions (`.github/workflows/ci.yml`) in `einsteintoolkit/carpetx` Docker containers.
 
 ## Architecture
 
 - Particles are managed via AMReX `AmrParticleContainer` with SoA attributes for momentum (`NuParticleContainers.hxx`)
 - `NuParticleContainer` handles particle push (geodesic integration), deposition, and I/O
 - Symbolic expressions in `Particles/wolfram/` generate C++ headers (`.hxx`) — do not edit generated headers directly
-- The thornlist `scripts/mctx.th` defines all external dependencies fetched by `download.sh`
 
 ## Key Patterns
 

--- a/agent_scripts/build_and_test.sh
+++ b/agent_scripts/build_and_test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+docker exec $CONTAINERARMLOCAL zsh -c '
+  cd /home/joe/Meitner/Cactus &&
+  ./simfactory/bin/sim build sim -j8 \
+    --machine actions-arm-real64 \
+    --thornlist=thornlists/mctx.th &&
+  make sim-testsuite
+'

--- a/scripts/mctx.th
+++ b/scripts/mctx.th
@@ -73,24 +73,24 @@ CactusBase/IOUtil
 CactusBase/SymBase
 CactusBase/Time
 
-# CactusUtils thorns
-!TARGET   = $ARR
-!TYPE     = git
-!URL      = https://bitbucket.org/cactuscode/cactusutils.git
-!REPO_PATH= $2
-!CHECKOUT = CactusUtils/Accelerator CactusUtils/OpenCLRunTime
-CactusUtils/Formaline
-CactusUtils/MemSpeed
-CactusUtils/NaNCatcher
-CactusUtils/Nice
-CactusUtils/NoMPI
-CactusUtils/SystemStatistics
-CactusUtils/SystemTopology
-CactusUtils/TerminationTrigger
-CactusUtils/TimerReport
-CactusUtils/Trigger
-CactusUtils/Vectors
-CactusUtils/WatchDog
+## CactusUtils thorns
+#!TARGET   = $ARR
+#!TYPE     = git
+#!URL      = https://bitbucket.org/cactuscode/cactusutils.git
+#!REPO_PATH= $2
+#!CHECKOUT = CactusUtils/Accelerator CactusUtils/OpenCLRunTime
+#CactusUtils/Formaline
+#CactusUtils/MemSpeed
+#CactusUtils/NaNCatcher
+#CactusUtils/Nice
+#CactusUtils/NoMPI
+#CactusUtils/SystemStatistics
+#CactusUtils/SystemTopology
+#CactusUtils/TerminationTrigger
+#CactusUtils/TimerReport
+#CactusUtils/Trigger
+#CactusUtils/Vectors
+#CactusUtils/WatchDog
 
 # Additional Cactus thorns
 !TARGET   = $ARR


### PR DESCRIPTION
## Summary
- Replace detailed build/test steps in CLAUDE.md and AGENTS.md with a single `agent_scripts/build_and_test.sh` script
- Remove SimFactory and thornlist references from documentation
- Comment out CactusUtils thorns in `scripts/mctx.th`

## Test plan
- [ ] Verify `agent_scripts/build_and_test.sh` runs correctly in the Docker environment
- [ ] Confirm build succeeds without CactusUtils thorns