### PR TITLE
Particles: refactor to pure SoA particle container

### DIFF
--- a/Particles/configuration.ccl
+++ b/Particles/configuration.ccl
@@ -1,6 +1,6 @@
 # Configuration definitions for thorn Particles
 
-REQUIRES Loop
+REQUIRES CarpetX Loop
 
 PROVIDES Particles
 {

--- a/Particles/interface.ccl
+++ b/Particles/interface.ccl
@@ -2,10 +2,7 @@
 
 IMPLEMENTS: Particles
 
+USES INCLUDE HEADER: driver.hxx
 USES INCLUDE HEADER: loop_device.hxx
 
 INCLUDES HEADER: NuParticleContainers.hxx IN NuParticleContainers.hxx
-
-PUBLIC:
-
-CCTK_REAL dalp TYPE=gf TAGS='checkpoint="no"' { dalpx dalpy dalpz } "Spatial derivative of ADM lapse function"

--- a/TestNuParticles/configuration.ccl
+++ b/TestNuParticles/configuration.ccl
@@ -1,3 +1,3 @@
 # Configuration definitions for thorn TestNuParticles
 
-REQUIRES Loop Particles
+REQUIRES CarpetX Loop Particles

--- a/TestNuParticles/interface.ccl
+++ b/TestNuParticles/interface.ccl
@@ -4,6 +4,7 @@ IMPLEMENTS: TestNuParticles
 
 INHERITS: ADMBaseX
 
+USES INCLUDE HEADER: driver.hxx
 USES INCLUDE HEADER: loop_device.hxx
 
 USES INCLUDE HEADER: NuParticleContainers.hxx

--- a/TestNuPcsArdBH/configuration.ccl
+++ b/TestNuPcsArdBH/configuration.ccl
@@ -1,3 +1,3 @@
 # Configuration definitions for thorn TestNuPcsArdBH
 
-REQUIRES Loop Particles
+REQUIRES CarpetX Loop Particles

--- a/TestNuPcsArdBH/interface.ccl
+++ b/TestNuPcsArdBH/interface.ccl
@@ -4,6 +4,7 @@ IMPLEMENTS: TestNuPcsArdBH
 
 INHERITS: ADMBaseX
 
+USES INCLUDE HEADER: driver.hxx
 USES INCLUDE HEADER: loop_device.hxx
 
 USES INCLUDE HEADER: NuParticleContainers.hxx

--- a/TestNuPcsArdBH/src/testnupcsardbh.cxx
+++ b/TestNuPcsArdBH/src/testnupcsardbh.cxx
@@ -10,30 +10,13 @@
 
 #include <NuParticleContainers.hxx>
 
-#include "../../../CarpetX/CarpetX/src/driver.hxx"
+#include <driver.hxx>
 
 namespace TestNuPcsArdBH {
 using namespace Loop;
 using namespace NuParticleContainers;
 using namespace amrex;
 using namespace std;
-
-using ParticleType = NuParticleContainer::ParticleType;
-
-CCTK_HOST CCTK_DEVICE void
-get_position_unit_cell(Real *r, const array<int, 3> &nppc, int i_part) {
-  int nx = nppc[0];
-  int ny = nppc[1];
-  int nz = nppc[2];
-
-  int ix_part = i_part / (ny * nz);
-  int iy_part = (i_part % (ny * nz)) % ny;
-  int iz_part = (i_part % (ny * nz)) / ny;
-
-  r[0] = (0.5 + ix_part) / nx;
-  r[1] = (0.5 + iy_part) / ny;
-  r[2] = (0.5 + iz_part) / nz;
-}
 
 extern "C" void TestNuPcsArdBH_InitFields(CCTK_ARGUMENTS) {
   DECLARE_CCTK_PARAMETERS;
@@ -137,7 +120,7 @@ extern "C" void TestNuPcsArdBH_InitParticles(CCTK_ARGUMENTS) {
           particles[std::make_pair(mfi.index(), mfi.LocalTileIndex())];
 
       // Determines the current size and the required new size
-      auto old_size = particle_tile.GetArrayOfStructs().size();
+      auto old_size = particle_tile.numParticles();
       auto new_size = old_size + num_to_add;
 
       // Crucially, this resizes the container only once, which is much more
@@ -147,10 +130,15 @@ extern "C" void TestNuPcsArdBH_InitParticles(CCTK_ARGUMENTS) {
       if (num_to_add == 0)
         continue;
 
-      // Gets raw pointers to the two different ways particle data is stored for
-      // performance reasons: Array of Struct (AoS) and Struct of Arrays (SoA)
-      ParticleType *pstruct = particle_tile.GetArrayOfStructs()().data();
-      auto arrdata = particle_tile.GetStructOfArrays().realarray();
+      // Get raw pointers to pure SoA particle data
+      auto &soa = particle_tile.GetStructOfArrays();
+      auto *AMREX_RESTRICT xp = soa.GetRealData(0).data();
+      auto *AMREX_RESTRICT yp = soa.GetRealData(1).data();
+      auto *AMREX_RESTRICT zp = soa.GetRealData(2).data();
+      auto *AMREX_RESTRICT pxp = soa.GetRealData(PIdx::px).data();
+      auto *AMREX_RESTRICT pyp = soa.GetRealData(PIdx::py).data();
+      auto *AMREX_RESTRICT pzp = soa.GetRealData(PIdx::pz).data();
+      auto *AMREX_RESTRICT idcpu_arr = soa.GetIdCPUData().data();
 
       int procID = ParallelDescriptor::MyProc();
 
@@ -203,20 +191,15 @@ extern "C" void TestNuPcsArdBH_InitParticles(CCTK_ARGUMENTS) {
               Real cosph = std::cos(ph);
               Real sinph = std::sin(ph);
 
-              // The core particle properties are written to the Array of
-              // Structs (AoS) memory layout
-              ParticleType &p = pstruct[pidx];
-              p.id() = pidx + 1;
-              p.cpu() = procID;
-              p.pos(0) = x;
-              p.pos(1) = y;
-              p.pos(2) = z;
-
-              // Write the remaining physical properties to the Struct of Arrays
-              // (SoA) memory layout
-              arrdata[PIdx::px][pidx] = pt * sinth * cosph;
-              arrdata[PIdx::py][pidx] = pt * sinth * sinph;
-              arrdata[PIdx::pz][pidx] = pt * costh;
+              // Write particle properties to pure SoA storage
+              amrex::ParticleIDWrapper<uint64_t>{idcpu_arr[pidx]} = pidx + 1;
+              amrex::ParticleCPUWrapper{idcpu_arr[pidx]} = procID;
+              xp[pidx] = x;
+              yp[pidx] = y;
+              zp[pidx] = z;
+              pxp[pidx] = pt * sinth * cosph;
+              pyp[pidx] = pt * sinth * sinph;
+              pzp[pidx] = pt * costh;
 
               ++pidx;
             }


### PR DESCRIPTION
## Summary

- Migrate `NuParticleContainer` from legacy AoS-hybrid layout (`AmrParticleContainer<0,0,9,0>`) to modern pure SoA layout (`AmrParticleContainer_impl<SoAParticle<N,0>,N,0>`)
- Eliminate `NuParIter` class; replace with `amrex::ParIterSoA` directly
- Implement custom ASCII writer for `OutputParticlesAscii` since AMReX's `WriteAsciiFile` is incompatible with pure SoA containers
- Clean up `driver.hxx` include paths to use Cactus header mechanism, remove dead code (`dalp` grid functions, `get_position_unit_cell`, commented-out methods)
- Update both test thorns for pure SoA particle initialization API

## Test plan

- [x] `./agent_scripts/build.sh` succeeds
- [x] `./agent_scripts/test.sh` succeeds (TestNuPcsArdBH reference output matches byte-exactly)
- [x] No `GetArrayOfStructs` calls remain in any MCTX source file
- [x] No `ParticleType` alias or AoS access patterns remain
- [x] No hardcoded `../../../CarpetX` paths remain