### PR TITLE
Fix agent_scripts/test.sh to detect failed tests

### DIFF
--- a/agent_scripts/test.sh
+++ b/agent_scripts/test.sh
@@ -5,7 +5,13 @@ if docker exec $CONTAINERARMLOCAL zsh -c '
   cd /home/joe/Meitner/Cactus &&
   make sim-testsuite
 ' > "$log" 2>&1; then
-  echo "✓ test"
+  if grep -q 'Number failed            -> 0' "$log"; then
+    echo "✓ test"
+  else
+    cat "$log"
+    echo "✗ test failed" >&2
+    exit 1
+  fi
 else
   cat "$log"
   echo "✗ test failed" >&2


### PR DESCRIPTION
## Summary
- The Cactus test suite can return exit code 0 even when individual tests fail
- `agent_scripts/test.sh` previously only checked the exit code, so it reported success despite test failures
- Added a grep check on the summary log for the `Number failed -> 0` pattern (matching what `scripts/test.sh` already does)
- If the pattern is not found, the script now dumps the log and exits with failure

## Test plan
- [ ] Run `./agent_scripts/test.sh` with all tests passing — should print `✓ test`
- [ ] Run `./agent_scripts/test.sh` with a failing test — should print the log and `✗ test failed`