### PR TITLE
Add AMReX-native particle checkpoint/restart

### DIFF
--- a/Particles/param.ccl
+++ b/Particles/param.ccl
@@ -12,6 +12,18 @@ INT out_tsv_every "Output in TSV format every that many iterations" STEERABLE=al
   1:* :: "every that many iterations"
 } 0
 
+INT out_checkpoint_every "Output AMReX checkpoint every that many iterations" STEERABLE=always
+{
+  0 :: "never output checkpoint"
+  1:* :: "every that many iterations"
+} 0
+
+STRING checkpoint_particle_dir "Directory to read particle checkpoint from for restart" STEERABLE=recover
+{
+  "" :: "no restart"
+  .* :: "directory path"
+} ""
+
 
 SHARES: IO
 

--- a/Particles/schedule.ccl
+++ b/Particles/schedule.ccl
@@ -5,3 +5,9 @@ SCHEDULE NuParticleContainers_Setup AT initial
   LANG: C
   OPTIONS: global
 } "Setup Neutrino Particle Containers"
+
+SCHEDULE NuParticleContainers_Restart AT initial AFTER NuParticleContainers_Setup
+{
+  LANG: C
+  OPTIONS: global
+} "Restart Neutrino Particles from checkpoint (if configured)"

--- a/Particles/src/NuParticleContainers.cxx
+++ b/Particles/src/NuParticleContainers.cxx
@@ -3,6 +3,8 @@
 #include "../wolfram/particles_geodesic.hxx"
 #include "Particles.hxx"
 
+#include <driver.hxx>
+
 #include <fstream>
 
 namespace NuParticleContainers {
@@ -277,6 +279,29 @@ void NuParticleContainer::OutputParticlesPlot(CCTK_ARGUMENTS) {
   }
 }
 
+void NuParticleContainer::OutputParticlesCheckpoint(CCTK_ARGUMENTS) {
+  DECLARE_CCTK_PARAMETERS;
+
+  const int it = cctkGH->cctk_iteration;
+  if (out_checkpoint_every > 0 && it % out_checkpoint_every == 0) {
+    const std::string dir =
+        std::string(out_dir) + "/" + amrex::Concatenate("ptcl_chk_", it);
+    amrex::Print() << "  Writing particle checkpoint " << dir << "\n";
+
+    // Names for user SoA attributes (positions excluded for pure SoA)
+    const amrex::Vector<std::string> real_comp_names = {
+        "px", "py", "pz", "x0", "y0", "z0", "px0", "py0", "pz0"};
+    const amrex::Vector<std::string> int_comp_names = {};
+
+    this->Checkpoint(dir, "particles", real_comp_names, int_comp_names);
+  }
+}
+
+void NuParticleContainer::RestartParticles(const std::string &dir) {
+  amrex::Print() << "  Restarting particles from " << dir << "\n";
+  this->Restart(dir, "particles");
+}
+
 extern "C" void NuParticleContainers_Setup(CCTK_ARGUMENTS) {
   DECLARE_CCTK_PARAMETERS;
 
@@ -285,6 +310,18 @@ extern "C" void NuParticleContainers_Setup(CCTK_ARGUMENTS) {
     g_nupcs.emplace_back(
         std::make_unique<NuParticleContainer>(patchdata.amrcore.get()));
   } // for patch
+}
+
+extern "C" void NuParticleContainers_Restart(CCTK_ARGUMENTS) {
+  DECLARE_CCTK_PARAMETERS;
+
+  const std::string dir(checkpoint_particle_dir);
+  if (dir.empty())
+    return;
+
+  for (int patch = 0; patch < CarpetX::ghext->num_patches(); ++patch) {
+    g_nupcs.at(patch)->RestartParticles(dir);
+  }
 }
 
 } // namespace NuParticleContainers

--- a/Particles/src/NuParticleContainers.hxx
+++ b/Particles/src/NuParticleContainers.hxx
@@ -1,10 +1,11 @@
 #ifndef NUPARTICLECONTAINERS_HXX
 #define NUPARTICLECONTAINERS_HXX
 
+#include <cctk.h>
+#include <cctk_Arguments.h>
+
 #include <AMReX_AmrParticles.H>
 #include <AMReX_Particles.H>
-
-#include <driver.hxx>
 
 namespace NuParticleContainers {
 
@@ -46,6 +47,10 @@ public:
   void OutputParticlesAscii(CCTK_ARGUMENTS);
 
   void OutputParticlesPlot(CCTK_ARGUMENTS);
+
+  void OutputParticlesCheckpoint(CCTK_ARGUMENTS);
+
+  void RestartParticles(const std::string &dir);
 };
 
 extern std::vector<std::unique_ptr<NuParticleContainer>> g_nupcs;

--- a/TestNuParticles/src/testnuparticles.cxx
+++ b/TestNuParticles/src/testnuparticles.cxx
@@ -106,9 +106,7 @@ extern "C" void TestNuParticles_InitParticles(CCTK_ARGUMENTS) {
       int num_to_add =
           offsets[tile_box.numPts() - 1] + counts[tile_box.numPts() - 1];
 
-      auto &particles = pc->GetParticles(lev);
-      auto &particle_tile =
-          particles[std::make_pair(mfi.index(), mfi.LocalTileIndex())];
+      auto &particle_tile = pc->DefineAndReturnParticleTile(lev, mfi);
 
       // Determines the current size and the required new size
       auto old_size = particle_tile.numParticles();
@@ -201,6 +199,11 @@ extern "C" void TestNuParticles_InitParticles(CCTK_ARGUMENTS) {
     auto &pc = g_nupcs.at(patch);
     pc->OutputParticlesPlot(CCTK_PASS_CTOC);
   } // for patch
+
+  for (int patch = 0; patch < ghext->num_patches(); ++patch) {
+    auto &pc = g_nupcs.at(patch);
+    pc->OutputParticlesCheckpoint(CCTK_PASS_CTOC);
+  } // for patch
 }
 
 extern "C" void TestNuParticles_PushAndDeposeParticles(CCTK_ARGUMENTS) {
@@ -252,6 +255,11 @@ extern "C" void TestNuParticles_PushAndDeposeParticles(CCTK_ARGUMENTS) {
   for (int patch = 0; patch < ghext->num_patches(); ++patch) {
     auto &pc = g_nupcs.at(patch);
     pc->OutputParticlesPlot(CCTK_PASS_CTOC);
+  } // for patch
+
+  for (int patch = 0; patch < ghext->num_patches(); ++patch) {
+    auto &pc = g_nupcs.at(patch);
+    pc->OutputParticlesCheckpoint(CCTK_PASS_CTOC);
   } // for patch
 }
 

--- a/TestNuPcsArdBH/src/testnupcsardbh.cxx
+++ b/TestNuPcsArdBH/src/testnupcsardbh.cxx
@@ -115,9 +115,7 @@ extern "C" void TestNuPcsArdBH_InitParticles(CCTK_ARGUMENTS) {
       int num_to_add =
           offsets[tile_box.numPts() - 1] + counts[tile_box.numPts() - 1];
 
-      auto &particles = pc->GetParticles(lev);
-      auto &particle_tile =
-          particles[std::make_pair(mfi.index(), mfi.LocalTileIndex())];
+      auto &particle_tile = pc->DefineAndReturnParticleTile(lev, mfi);
 
       // Determines the current size and the required new size
       auto old_size = particle_tile.numParticles();
@@ -211,6 +209,11 @@ extern "C" void TestNuPcsArdBH_InitParticles(CCTK_ARGUMENTS) {
     auto &pc = g_nupcs.at(patch);
     pc->OutputParticlesPlot(CCTK_PASS_CTOC);
   } // for patch
+
+  for (int patch = 0; patch < ghext->num_patches(); ++patch) {
+    auto &pc = g_nupcs.at(patch);
+    pc->OutputParticlesCheckpoint(CCTK_PASS_CTOC);
+  } // for patch
 }
 
 extern "C" void TestNuPcsArdBH_PushAndDeposeParticles(CCTK_ARGUMENTS) {
@@ -262,6 +265,11 @@ extern "C" void TestNuPcsArdBH_PushAndDeposeParticles(CCTK_ARGUMENTS) {
   for (int patch = 0; patch < ghext->num_patches(); ++patch) {
     auto &pc = g_nupcs.at(patch);
     pc->OutputParticlesPlot(CCTK_PASS_CTOC);
+  } // for patch
+
+  for (int patch = 0; patch < ghext->num_patches(); ++patch) {
+    auto &pc = g_nupcs.at(patch);
+    pc->OutputParticlesCheckpoint(CCTK_PASS_CTOC);
   } // for patch
 }
 


### PR DESCRIPTION
## Summary

- **Decouple public header from CarpetX**: Remove `driver.hxx` from `NuParticleContainers.hxx` (only AMReX types needed); move it to the `.cxx` file. Modernize test thorns to use `DefineAndReturnParticleTile` instead of raw `GetParticles` map access.
- **Add AMReX-native checkpoint/restart**: `OutputParticlesCheckpoint` wraps AMReX `Checkpoint()` and `RestartParticles` wraps AMReX `Restart()` on `NuParticleContainer`. New parameters `out_checkpoint_every` and `checkpoint_particle_dir` control checkpoint frequency and restart source.
- **Schedule restart at initial**: `NuParticleContainers_Restart` runs after setup; no-op when `checkpoint_particle_dir` is empty.

## Test plan

- [x] `./agent_scripts/build.sh` succeeds
- [x] `./agent_scripts/test.sh` succeeds (existing TSV reference output unchanged)
- [x] Manual: checkpoint directories appear with `out_checkpoint_every = 1`
- [x] Manual: checkpoint contains expected structure (`Header`, `Level_0/`, `DATA_*`)
- [x] Manual: particles restored correctly with `checkpoint_particle_dir` set
- [x] Manual: existing test behavior unchanged without `checkpoint_particle_dir`