### PR TITLE
CLAUDE.md: update Architecture section for recent changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,8 +29,9 @@ Each thorn follows the Cactus format:
 
 ## Architecture
 
-- Particles are managed via AMReX `AmrParticleContainer` with SoA attributes for momentum (`NuParticleContainers.hxx`)
+- Particles are managed via AMReX `AmrParticleContainer` with SoA attributes for position, momentum, and particle properties (`NuParticleContainers.hxx`)
 - `NuParticleContainer` handles particle push (geodesic integration), deposition, and I/O
+- Multi-level AMR supported — particle containers resize across refinement levels; setup runs at BASEGRID
 - Symbolic expressions in `Particles/wolfram/` generate C++ headers (`.hxx`) — do not edit generated headers directly
 
 ## Key Patterns


### PR DESCRIPTION
## Summary
- Updated SoA attribute description from "for momentum" to "for position, momentum, and particle properties" to reflect recently added attributes (time, num_neutrinos, pt, species, cell_id)
- Added note about multi-level AMR support (particle container resizing across refinement levels, BASEGRID scheduling)

## Test plan
- [ ] Verify CLAUDE.md renders correctly on GitHub